### PR TITLE
feat: GRM (Girls Relationship Management) 機能の基盤実装

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -34,6 +34,13 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="grm"
+        options={{
+          title: 'GRM',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="person.2.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
         name="goal-settings"
         options={{
           title: '目標設定',

--- a/app/(tabs)/grm.tsx
+++ b/app/(tabs)/grm.tsx
@@ -1,0 +1,163 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Girl } from '@/src/types/grm';
+import { useGRM } from '@/contexts/GRMContext';
+import { PipelineView } from '@/components/grm/PipelineView';
+import { GirlListView } from '@/components/grm/GirlListView';
+import { GirlDetailView } from '@/components/grm/GirlDetailView';
+import { GirlRegistrationForm } from '@/components/grm/GirlRegistrationForm';
+
+type ViewMode = 'pipeline' | 'list';
+
+export default function GRMScreen() {
+  const { girls, loading, fetchGirls } = useGRM();
+  const [viewMode, setViewMode] = useState<ViewMode>('pipeline');
+  const [selectedGirl, setSelectedGirl] = useState<Girl | null>(null);
+  const [showRegistration, setShowRegistration] = useState(false);
+
+  useEffect(() => {
+    fetchGirls();
+  }, [fetchGirls]);
+
+  // 詳細ビューを表示中
+  if (selectedGirl) {
+    const currentGirl = girls.find(g => g.id === selectedGirl.id) ?? selectedGirl;
+    return (
+      <SafeAreaView style={styles.safeArea} edges={['top']}>
+        <GirlDetailView
+          girl={currentGirl}
+          onBack={() => setSelectedGirl(null)}
+          onEdit={(girl) => {
+            // TODO: 編集フォームを開く（Phase 3以降で詳細実装）
+          }}
+        />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
+      <View style={styles.header}>
+        <Text style={styles.title}>GRM</Text>
+        <View style={styles.headerRight}>
+          <Text style={styles.girlCount}>{girls.length}人</Text>
+          <TouchableOpacity onPress={() => setShowRegistration(true)} style={styles.addBtn}>
+            <Text style={styles.addBtnText}>+ 追加</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* ビュー切り替えタブ */}
+      <View style={styles.viewToggle}>
+        <TouchableOpacity
+          style={[styles.toggleBtn, viewMode === 'pipeline' && styles.toggleBtnActive]}
+          onPress={() => setViewMode('pipeline')}
+        >
+          <Text style={[styles.toggleBtnText, viewMode === 'pipeline' && styles.toggleBtnTextActive]}>
+            パイプライン
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.toggleBtn, viewMode === 'list' && styles.toggleBtnActive]}
+          onPress={() => setViewMode('list')}
+        >
+          <Text style={[styles.toggleBtnText, viewMode === 'list' && styles.toggleBtnTextActive]}>
+            リスト
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading && girls.length === 0 ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#4F46E5" />
+        </View>
+      ) : viewMode === 'pipeline' ? (
+        <PipelineView girls={girls} onSelectGirl={setSelectedGirl} />
+      ) : (
+        <GirlListView girls={girls} onSelectGirl={setSelectedGirl} />
+      )}
+
+      {/* 手動追加フォーム（セッションなし） */}
+      <GirlRegistrationForm
+        sessionId={null}
+        sourceType="get_contact"
+        visible={showRegistration}
+        onClose={() => setShowRegistration(false)}
+        onRegistered={fetchGirls}
+        allowSkip={false}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: '#111827',
+  },
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  girlCount: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  addBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    backgroundColor: '#4F46E5',
+    borderRadius: 8,
+  },
+  addBtnText: {
+    fontSize: 14,
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+  viewToggle: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    gap: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  toggleBtn: {
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: '#F3F4F6',
+  },
+  toggleBtnActive: {
+    backgroundColor: '#111827',
+  },
+  toggleBtnText: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  toggleBtnTextActive: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,8 @@ import { RecordProvider } from '@/contexts/RecordContext';
 import { GoalProvider } from '@/contexts/GoalContext';
 import { CounterProvider } from '@/contexts/CounterContext';
 import { ProfileProvider } from '@/contexts/ProfileContext';
+import { SessionProvider } from '@/contexts/SessionContext';
+import { GRMProvider } from '@/contexts/GRMContext';
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
@@ -115,18 +117,22 @@ function RootLayout() {
           <CounterProvider>
             <RecordProvider>
               <GoalProvider>
-                <PaperProvider theme={theme}>
-                  <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-                    {/* AuthRedirectコンポーネントを有効化 */}
-                    <AuthRedirect />
-                    <Stack initialRouteName="(auth)">
-                      <Stack.Screen name="(auth)" options={{ headerShown: false }} />
-                      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-                      <Stack.Screen name="+not-found" />
-                    </Stack>
-                    <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
-                  </ThemeProvider>
-                </PaperProvider>
+                <SessionProvider>
+                  <GRMProvider>
+                    <PaperProvider theme={theme}>
+                      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+                        {/* AuthRedirectコンポーネントを有効化 */}
+                        <AuthRedirect />
+                        <Stack initialRouteName="(auth)">
+                          <Stack.Screen name="(auth)" options={{ headerShown: false }} />
+                          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                          <Stack.Screen name="+not-found" />
+                        </Stack>
+                        <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+                      </ThemeProvider>
+                    </PaperProvider>
+                  </GRMProvider>
+                </SessionProvider>
               </GoalProvider>
             </RecordProvider>
           </CounterProvider>

--- a/components/grm/AddApoForm.tsx
+++ b/components/grm/AddApoForm.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import {
+  View, Text, StyleSheet, TextInput, TouchableOpacity,
+  Modal, KeyboardAvoidingView, Platform, ScrollView, Alert,
+} from 'react-native';
+import { ApoInsert } from '@/src/types/grm';
+import { useGRM } from '@/contexts/GRMContext';
+
+interface Props {
+  girlId: string;
+  visible: boolean;
+  onClose: () => void;
+  onAdded: () => void;
+}
+
+export function AddApoForm({ girlId, visible, onClose, onAdded }: Props) {
+  const { addApo } = useGRM();
+  const [apoDate, setApoDate] = useState(new Date().toISOString().split('T')[0]);
+  const [location, setLocation] = useState('');
+  const [spent, setSpent] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!apoDate) {
+      Alert.alert('エラー', '日付を入力してください');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const apo = await addApo({
+        girlId,
+        apoDate,
+        location: location || null,
+        spent: spent ? parseInt(spent, 10) : 0,
+        notes: notes || null,
+      });
+
+      if (apo) {
+        setApoDate(new Date().toISOString().split('T')[0]);
+        setLocation('');
+        setSpent('');
+        setNotes('');
+        onAdded();
+        onClose();
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="pageSheet" onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={styles.header}>
+          <TouchableOpacity onPress={onClose}>
+            <Text style={styles.cancelBtn}>キャンセル</Text>
+          </TouchableOpacity>
+          <Text style={styles.title}>アポを追加</Text>
+          <TouchableOpacity onPress={handleSubmit} disabled={submitting}>
+            <Text style={[styles.saveBtn, submitting && styles.saveBtnDisabled]}>保存</Text>
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView style={styles.form}>
+          <Text style={styles.label}>日付 *</Text>
+          <TextInput
+            style={styles.input}
+            value={apoDate}
+            onChangeText={setApoDate}
+            placeholder="YYYY-MM-DD"
+          />
+
+          <Text style={styles.label}>場所</Text>
+          <TextInput
+            style={styles.input}
+            value={location}
+            onChangeText={setLocation}
+            placeholder="例: 渋谷、新宿"
+          />
+
+          <Text style={styles.label}>使用金額 (円)</Text>
+          <TextInput
+            style={styles.input}
+            value={spent}
+            onChangeText={setSpent}
+            placeholder="0"
+            keyboardType="numeric"
+          />
+
+          <Text style={styles.label}>メモ</Text>
+          <TextInput
+            style={[styles.input, styles.textArea]}
+            value={notes}
+            onChangeText={setNotes}
+            placeholder="メモを入力"
+            multiline
+            numberOfLines={4}
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  cancelBtn: {
+    fontSize: 16,
+    color: '#6B7280',
+  },
+  saveBtn: {
+    fontSize: 16,
+    color: '#4F46E5',
+    fontWeight: '600',
+  },
+  saveBtnDisabled: {
+    opacity: 0.5,
+  },
+  form: {
+    padding: 16,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#374151',
+    marginBottom: 6,
+    marginTop: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: '#111827',
+  },
+  textArea: {
+    height: 100,
+    textAlignVertical: 'top',
+  },
+});

--- a/components/grm/ApoTimeline.tsx
+++ b/components/grm/ApoTimeline.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Apo } from '@/src/types/grm';
+import { format } from 'date-fns';
+import { ja } from 'date-fns/locale';
+
+interface Props {
+  apos: Apo[];
+  onDeleteApo?: (apo: Apo) => void;
+}
+
+export function ApoTimeline({ apos, onDeleteApo }: Props) {
+  if (apos.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>アポ記録はまだありません</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {apos.map((apo, index) => (
+        <View key={apo.id} style={styles.item}>
+          <View style={styles.timeline}>
+            <View style={styles.dot} />
+            {index < apos.length - 1 && <View style={styles.line} />}
+          </View>
+
+          <View style={styles.content}>
+            <View style={styles.header}>
+              <Text style={styles.apoNumber}>Apo {apo.apoNumber}</Text>
+              <Text style={styles.date}>
+                {format(new Date(apo.apoDate), 'M月d日(EEE)', { locale: ja })}
+              </Text>
+            </View>
+
+            {apo.location && (
+              <Text style={styles.location}>📍 {apo.location}</Text>
+            )}
+
+            {apo.spent > 0 && (
+              <Text style={styles.spent}>💰 ¥{apo.spent.toLocaleString()}</Text>
+            )}
+
+            {apo.notes && (
+              <Text style={styles.notes}>{apo.notes}</Text>
+            )}
+
+            {onDeleteApo && (
+              <TouchableOpacity onPress={() => onDeleteApo(apo)} style={styles.deleteBtn}>
+                <Text style={styles.deleteBtnText}>削除</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingLeft: 4,
+  },
+  empty: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  emptyText: {
+    color: '#9CA3AF',
+    fontSize: 14,
+  },
+  item: {
+    flexDirection: 'row',
+    marginBottom: 16,
+  },
+  timeline: {
+    width: 20,
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  dot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: '#6366F1',
+    marginTop: 4,
+  },
+  line: {
+    width: 2,
+    flex: 1,
+    backgroundColor: '#E5E7EB',
+    marginTop: 4,
+  },
+  content: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+    borderRadius: 10,
+    padding: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  apoNumber: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#4F46E5',
+  },
+  date: {
+    fontSize: 13,
+    color: '#6B7280',
+  },
+  location: {
+    fontSize: 13,
+    color: '#374151',
+    marginBottom: 2,
+  },
+  spent: {
+    fontSize: 13,
+    color: '#374151',
+    marginBottom: 2,
+  },
+  notes: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginTop: 4,
+    lineHeight: 18,
+  },
+  deleteBtn: {
+    alignSelf: 'flex-end',
+    marginTop: 6,
+  },
+  deleteBtnText: {
+    fontSize: 12,
+    color: '#EF4444',
+  },
+});

--- a/components/grm/GirlCard.tsx
+++ b/components/grm/GirlCard.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Girl } from '@/src/types/grm';
+import { StatusBadge } from './StatusBadge';
+import { format } from 'date-fns';
+import { ja } from 'date-fns/locale';
+
+interface Props {
+  girl: Girl;
+  onPress: (girl: Girl) => void;
+}
+
+export function GirlCard({ girl, onPress }: Props) {
+  const metAt = format(new Date(girl.createdAt), 'M/d', { locale: ja });
+
+  return (
+    <TouchableOpacity style={styles.card} onPress={() => onPress(girl)} activeOpacity={0.7}>
+      <View style={styles.header}>
+        <Text style={styles.nickname} numberOfLines={1}>{girl.nickname}</Text>
+        <StatusBadge status={girl.status} size="sm" />
+      </View>
+
+      <View style={styles.meta}>
+        <Text style={styles.metaText}>出会い: {metAt}</Text>
+        {girl.apoCount > 0 && (
+          <Text style={styles.metaText}>アポ: {girl.apoCount}回</Text>
+        )}
+      </View>
+
+      {girl.rating !== null && (
+        <View style={styles.ratingRow}>
+          {Array.from({ length: 10 }).map((_, i) => (
+            <Text key={i} style={[styles.star, i < (girl.rating ?? 0) ? styles.starFilled : styles.starEmpty]}>
+              ★
+            </Text>
+          ))}
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  nickname: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#111827',
+    flex: 1,
+    marginRight: 8,
+  },
+  meta: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  metaText: {
+    fontSize: 12,
+    color: '#6B7280',
+  },
+  ratingRow: {
+    flexDirection: 'row',
+    marginTop: 4,
+  },
+  star: {
+    fontSize: 10,
+  },
+  starFilled: {
+    color: '#F59E0B',
+  },
+  starEmpty: {
+    color: '#D1D5DB',
+  },
+});

--- a/components/grm/GirlDetailView.tsx
+++ b/components/grm/GirlDetailView.tsx
@@ -1,0 +1,373 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View, Text, StyleSheet, ScrollView, TouchableOpacity, Alert,
+} from 'react-native';
+import { Girl, Apo, GRMStatus, GRM_STATUS_LABELS } from '@/src/types/grm';
+import { StatusBadge } from './StatusBadge';
+import { ApoTimeline } from './ApoTimeline';
+import { AddApoForm } from './AddApoForm';
+import { useGRM } from '@/contexts/GRMContext';
+import { format } from 'date-fns';
+import { ja } from 'date-fns/locale';
+
+const MANUAL_STATUSES: GRMStatus[] = ['sex', 'ltr', 'graduate'];
+
+interface Props {
+  girl: Girl;
+  onBack: () => void;
+  onEdit: (girl: Girl) => void;
+}
+
+export function GirlDetailView({ girl, onBack, onEdit }: Props) {
+  const { getAposByGirl, updateGirlStatus, deleteApo, deleteGirl } = useGRM();
+  const [apos, setApos] = useState<Apo[]>([]);
+  const [showAddApo, setShowAddApo] = useState(false);
+
+  const loadApos = useCallback(async () => {
+    const fetched = await getAposByGirl(girl.id);
+    setApos(fetched);
+  }, [girl.id, getAposByGirl]);
+
+  useEffect(() => {
+    loadApos();
+  }, [loadApos]);
+
+  const handleStatusChange = async (status: GRMStatus) => {
+    Alert.alert(
+      'ステータス変更',
+      `${GRM_STATUS_LABELS[status]} に変更しますか？`,
+      [
+        { text: 'キャンセル', style: 'cancel' },
+        {
+          text: '変更', onPress: async () => {
+            await updateGirlStatus(girl.id, status);
+          }
+        },
+      ]
+    );
+  };
+
+  const handleDeleteApo = async (apo: Apo) => {
+    Alert.alert('アポを削除', 'Apo ' + apo.apoNumber + ' を削除しますか？', [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: '削除', style: 'destructive', onPress: async () => {
+          await deleteApo(apo.id, girl.id);
+          loadApos();
+        }
+      },
+    ]);
+  };
+
+  const handleDeleteGirl = () => {
+    Alert.alert('削除', `${girl.nickname} を削除しますか？この操作は取り消せません。`, [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: '削除', style: 'destructive', onPress: async () => {
+          await deleteGirl(girl.id);
+          onBack();
+        }
+      },
+    ]);
+  };
+
+  const metAt = format(new Date(girl.createdAt), 'yyyy年M月d日', { locale: ja });
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.navBar}>
+        <TouchableOpacity onPress={onBack} style={styles.backBtn}>
+          <Text style={styles.backBtnText}>‹ 戻る</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => onEdit(girl)}>
+          <Text style={styles.editBtn}>編集</Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView style={styles.scroll}>
+        {/* プロフィールヘッダー */}
+        <View style={styles.profileHeader}>
+          <View style={styles.profileTop}>
+            <Text style={styles.nickname}>{girl.nickname}</Text>
+            <StatusBadge status={girl.status} />
+          </View>
+          <Text style={styles.metAt}>出会い: {metAt}</Text>
+          {girl.rating !== null && (
+            <View style={styles.ratingRow}>
+              {Array.from({ length: 10 }).map((_, i) => (
+                <Text key={i} style={[styles.star, i < (girl.rating ?? 0) ? styles.starFilled : styles.starEmpty]}>
+                  ★
+                </Text>
+              ))}
+              <Text style={styles.ratingNum}>{girl.rating}/10</Text>
+            </View>
+          )}
+        </View>
+
+        {/* ステータス変更ボタン */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>ステータス変更</Text>
+          <View style={styles.statusBtns}>
+            {MANUAL_STATUSES.map(s => (
+              <TouchableOpacity
+                key={s}
+                style={[styles.statusBtn, girl.status === s && styles.statusBtnActive]}
+                onPress={() => handleStatusChange(s)}
+              >
+                <Text style={[styles.statusBtnText, girl.status === s && styles.statusBtnTextActive]}>
+                  {GRM_STATUS_LABELS[s]}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        {/* 基本情報 */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>基本情報</Text>
+          <View style={styles.infoGrid}>
+            {girl.height && <InfoRow label="身長" value={`${girl.height}cm`} />}
+            {girl.bodyType && <InfoRow label="体型" value={girl.bodyType} />}
+            {girl.birthday && (
+              <InfoRow label="生年月日" value={format(new Date(girl.birthday), 'yyyy年M月d日', { locale: ja })} />
+            )}
+            {girl.occupation && <InfoRow label="職業" value={girl.occupation} />}
+            {girl.nationality && <InfoRow label="国籍" value={girl.nationality} />}
+            {girl.residence && <InfoRow label="居住地" value={girl.residence} />}
+          </View>
+        </View>
+
+        {/* 統計 */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>統計</Text>
+          <View style={styles.statsRow}>
+            <View style={styles.statItem}>
+              <Text style={styles.statValue}>{girl.apoCount}</Text>
+              <Text style={styles.statLabel}>アポ回数</Text>
+            </View>
+            <View style={styles.statItem}>
+              <Text style={styles.statValue}>¥{girl.totalSpent.toLocaleString()}</Text>
+              <Text style={styles.statLabel}>合計使用金額</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* アポ履歴 */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>アポ履歴</Text>
+            <TouchableOpacity onPress={() => setShowAddApo(true)} style={styles.addApoBtn}>
+              <Text style={styles.addApoBtnText}>+ アポを追加</Text>
+            </TouchableOpacity>
+          </View>
+          <ApoTimeline apos={apos} onDeleteApo={handleDeleteApo} />
+        </View>
+
+        {/* メモ */}
+        {girl.notes && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>メモ</Text>
+            <Text style={styles.notes}>{girl.notes}</Text>
+          </View>
+        )}
+
+        {/* 削除 */}
+        <TouchableOpacity style={styles.deleteBtn} onPress={handleDeleteGirl}>
+          <Text style={styles.deleteBtnText}>この女性を削除</Text>
+        </TouchableOpacity>
+      </ScrollView>
+
+      <AddApoForm
+        girlId={girl.id}
+        visible={showAddApo}
+        onClose={() => setShowAddApo(false)}
+        onAdded={loadApos}
+      />
+    </View>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={infoStyles.row}>
+      <Text style={infoStyles.label}>{label}</Text>
+      <Text style={infoStyles.value}>{value}</Text>
+    </View>
+  );
+}
+
+const infoStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  label: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  value: {
+    fontSize: 14,
+    color: '#111827',
+    fontWeight: '500',
+  },
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  navBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  backBtn: {},
+  backBtnText: {
+    fontSize: 17,
+    color: '#4F46E5',
+  },
+  editBtn: {
+    fontSize: 16,
+    color: '#4F46E5',
+  },
+  scroll: {
+    flex: 1,
+  },
+  profileHeader: {
+    padding: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  profileTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  nickname: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  metAt: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginBottom: 6,
+  },
+  ratingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 1,
+  },
+  star: {
+    fontSize: 16,
+  },
+  starFilled: {
+    color: '#F59E0B',
+  },
+  starEmpty: {
+    color: '#D1D5DB',
+  },
+  ratingNum: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginLeft: 4,
+  },
+  section: {
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 12,
+  },
+  statusBtns: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  statusBtn: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  statusBtnActive: {
+    backgroundColor: '#4F46E5',
+    borderColor: '#4F46E5',
+  },
+  statusBtnText: {
+    fontSize: 14,
+    color: '#374151',
+  },
+  statusBtnTextActive: {
+    color: '#FFFFFF',
+  },
+  infoGrid: {},
+  statsRow: {
+    flexDirection: 'row',
+    gap: 16,
+  },
+  statItem: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+    borderRadius: 10,
+    padding: 14,
+    alignItems: 'center',
+  },
+  statValue: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  statLabel: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginTop: 2,
+  },
+  addApoBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: '#EEF2FF',
+    borderRadius: 8,
+  },
+  addApoBtnText: {
+    fontSize: 13,
+    color: '#4F46E5',
+    fontWeight: '600',
+  },
+  notes: {
+    fontSize: 14,
+    color: '#374151',
+    lineHeight: 20,
+  },
+  deleteBtn: {
+    margin: 16,
+    padding: 14,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#FCA5A5',
+    alignItems: 'center',
+  },
+  deleteBtnText: {
+    fontSize: 14,
+    color: '#EF4444',
+  },
+});

--- a/components/grm/GirlListView.tsx
+++ b/components/grm/GirlListView.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import { Girl, GRMStatus, GRM_STATUS_LABELS, GRM_STATUS_ORDER } from '@/src/types/grm';
+import { GirlCard } from './GirlCard';
+
+type SortKey = 'updatedAt' | 'createdAt' | 'rating' | 'totalSpent';
+
+const SORT_LABELS: Record<SortKey, string> = {
+  updatedAt: '最終更新',
+  createdAt: '出会った日',
+  rating: '評価',
+  totalSpent: '使用金額',
+};
+
+interface Props {
+  girls: Girl[];
+  onSelectGirl: (girl: Girl) => void;
+}
+
+export function GirlListView({ girls, onSelectGirl }: Props) {
+  const [sortKey, setSortKey] = useState<SortKey>('updatedAt');
+  const [filterStatus, setFilterStatus] = useState<GRMStatus | null>(null);
+
+  const filtered = filterStatus
+    ? girls.filter(g => g.status === filterStatus)
+    : girls;
+
+  const sorted = [...filtered].sort((a, b) => {
+    switch (sortKey) {
+      case 'updatedAt':
+        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      case 'createdAt':
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      case 'rating':
+        return (b.rating ?? 0) - (a.rating ?? 0);
+      case 'totalSpent':
+        return b.totalSpent - a.totalSpent;
+    }
+  });
+
+  return (
+    <View style={styles.container}>
+      {/* ソート */}
+      <View style={styles.sortRow}>
+        {(Object.keys(SORT_LABELS) as SortKey[]).map(key => (
+          <TouchableOpacity
+            key={key}
+            style={[styles.sortBtn, sortKey === key && styles.sortBtnActive]}
+            onPress={() => setSortKey(key)}
+          >
+            <Text style={[styles.sortBtnText, sortKey === key && styles.sortBtnTextActive]}>
+              {SORT_LABELS[key]}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {/* ステータスフィルタ */}
+      <View style={styles.filterRow}>
+        <TouchableOpacity
+          style={[styles.filterBtn, filterStatus === null && styles.filterBtnActive]}
+          onPress={() => setFilterStatus(null)}
+        >
+          <Text style={[styles.filterBtnText, filterStatus === null && styles.filterBtnTextActive]}>
+            全て
+          </Text>
+        </TouchableOpacity>
+        {GRM_STATUS_ORDER.map(status => (
+          <TouchableOpacity
+            key={status}
+            style={[styles.filterBtn, filterStatus === status && styles.filterBtnActive]}
+            onPress={() => setFilterStatus(status)}
+          >
+            <Text style={[styles.filterBtnText, filterStatus === status && styles.filterBtnTextActive]}>
+              {GRM_STATUS_LABELS[status]}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <FlatList
+        data={sorted}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => (
+          <GirlCard girl={item} onPress={onSelectGirl} />
+        )}
+        ListEmptyComponent={
+          <Text style={styles.empty}>女性が登録されていません</Text>
+        }
+        contentContainerStyle={styles.list}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  sortRow: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    gap: 6,
+    flexWrap: 'wrap',
+  },
+  sortBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 16,
+    backgroundColor: '#F3F4F6',
+  },
+  sortBtnActive: {
+    backgroundColor: '#111827',
+  },
+  sortBtnText: {
+    fontSize: 12,
+    color: '#6B7280',
+  },
+  sortBtnTextActive: {
+    color: '#FFFFFF',
+  },
+  filterRow: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+    gap: 5,
+    flexWrap: 'wrap',
+  },
+  filterBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  filterBtnActive: {
+    backgroundColor: '#EEF2FF',
+    borderColor: '#6366F1',
+  },
+  filterBtnText: {
+    fontSize: 11,
+    color: '#6B7280',
+  },
+  filterBtnTextActive: {
+    color: '#6366F1',
+  },
+  list: {
+    padding: 16,
+    paddingTop: 4,
+  },
+  empty: {
+    textAlign: 'center',
+    color: '#9CA3AF',
+    marginTop: 40,
+    fontSize: 14,
+  },
+});

--- a/components/grm/GirlRegistrationForm.tsx
+++ b/components/grm/GirlRegistrationForm.tsx
@@ -1,0 +1,293 @@
+import React, { useState } from 'react';
+import {
+  View, Text, StyleSheet, TextInput, TouchableOpacity,
+  Modal, KeyboardAvoidingView, Platform, ScrollView, Alert,
+} from 'react-native';
+import { BodyType, GirlInsert } from '@/src/types/grm';
+import { useGRM } from '@/contexts/GRMContext';
+
+interface Props {
+  sessionId: string | null;
+  sourceType: 'get_contact' | 'instant_cv';
+  visible: boolean;
+  onClose: () => void;
+  onRegistered: () => void;
+  /** スキップ可能な場合（任意登録） */
+  allowSkip?: boolean;
+}
+
+const BODY_TYPES: { value: BodyType; label: string }[] = [
+  { value: 'slim', label: 'スリム' },
+  { value: 'normal', label: '普通' },
+  { value: 'curvy', label: 'グラマー' },
+  { value: 'chubby', label: 'ぽっちゃり' },
+];
+
+export function GirlRegistrationForm({
+  sessionId, sourceType, visible, onClose, onRegistered, allowSkip = true,
+}: Props) {
+  const { createGirl } = useGRM();
+
+  const [nickname, setNickname] = useState('');
+  const [height, setHeight] = useState('');
+  const [bodyType, setBodyType] = useState<BodyType | null>(null);
+  const [birthday, setBirthday] = useState('');
+  const [occupation, setOccupation] = useState('');
+  const [nationality, setNationality] = useState('');
+  const [residence, setResidence] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = () => {
+    setNickname('');
+    setHeight('');
+    setBodyType(null);
+    setBirthday('');
+    setOccupation('');
+    setNationality('');
+    setResidence('');
+    setNotes('');
+  };
+
+  const handleSubmit = async () => {
+    if (!nickname.trim()) {
+      Alert.alert('エラー', 'ニックネームを入力してください');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const data: Omit<GirlInsert, 'userId'> = {
+        sourceSessionId: sessionId,
+        sourceType,
+        nickname: nickname.trim(),
+        height: height ? parseInt(height, 10) : null,
+        bodyType,
+        birthday: birthday || null,
+        occupation: occupation || null,
+        nationality: nationality || null,
+        residence: residence || null,
+        notes: notes || null,
+      };
+
+      const girl = await createGirl(data);
+      if (girl) {
+        reset();
+        onRegistered();
+        onClose();
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSkip = () => {
+    reset();
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="pageSheet" onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={styles.header}>
+          {allowSkip ? (
+            <TouchableOpacity onPress={handleSkip}>
+              <Text style={styles.skipBtn}>スキップ</Text>
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity onPress={onClose}>
+              <Text style={styles.cancelBtn}>キャンセル</Text>
+            </TouchableOpacity>
+          )}
+          <Text style={styles.title}>
+            {sourceType === 'get_contact' ? 'バンゲ' : '即'} を登録
+          </Text>
+          <TouchableOpacity onPress={handleSubmit} disabled={submitting}>
+            <Text style={[styles.saveBtn, submitting && styles.saveBtnDisabled]}>保存</Text>
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView style={styles.form}>
+          <Text style={styles.required}>* 必須</Text>
+
+          <Text style={styles.label}>ニックネーム *</Text>
+          <TextInput
+            style={styles.input}
+            value={nickname}
+            onChangeText={setNickname}
+            placeholder="例: 渋谷のギャル"
+            autoFocus
+          />
+
+          <Text style={styles.sectionHeader}>外見（任意）</Text>
+
+          <Text style={styles.label}>身長 (cm)</Text>
+          <TextInput
+            style={styles.input}
+            value={height}
+            onChangeText={setHeight}
+            placeholder="例: 160"
+            keyboardType="numeric"
+          />
+
+          <Text style={styles.label}>体型</Text>
+          <View style={styles.bodyTypeRow}>
+            {BODY_TYPES.map(({ value, label }) => (
+              <TouchableOpacity
+                key={value}
+                style={[styles.bodyTypeBtn, bodyType === value && styles.bodyTypeBtnActive]}
+                onPress={() => setBodyType(bodyType === value ? null : value)}
+              >
+                <Text style={[styles.bodyTypeBtnText, bodyType === value && styles.bodyTypeBtnTextActive]}>
+                  {label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          <Text style={styles.sectionHeader}>基本情報（任意）</Text>
+
+          <Text style={styles.label}>生年月日</Text>
+          <TextInput
+            style={styles.input}
+            value={birthday}
+            onChangeText={setBirthday}
+            placeholder="YYYY-MM-DD"
+          />
+
+          <Text style={styles.label}>職業</Text>
+          <TextInput
+            style={styles.input}
+            value={occupation}
+            onChangeText={setOccupation}
+            placeholder="例: 大学生、OL"
+          />
+
+          <Text style={styles.label}>国籍</Text>
+          <TextInput
+            style={styles.input}
+            value={nationality}
+            onChangeText={setNationality}
+            placeholder="例: 日本"
+          />
+
+          <Text style={styles.label}>居住地</Text>
+          <TextInput
+            style={styles.input}
+            value={residence}
+            onChangeText={setResidence}
+            placeholder="例: 渋谷区"
+          />
+
+          <Text style={styles.label}>メモ</Text>
+          <TextInput
+            style={[styles.input, styles.textArea]}
+            value={notes}
+            onChangeText={setNotes}
+            placeholder="メモを入力"
+            multiline
+            numberOfLines={4}
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  skipBtn: {
+    fontSize: 16,
+    color: '#9CA3AF',
+  },
+  cancelBtn: {
+    fontSize: 16,
+    color: '#6B7280',
+  },
+  saveBtn: {
+    fontSize: 16,
+    color: '#4F46E5',
+    fontWeight: '600',
+  },
+  saveBtnDisabled: {
+    opacity: 0.5,
+  },
+  form: {
+    padding: 16,
+  },
+  required: {
+    fontSize: 12,
+    color: '#9CA3AF',
+    marginBottom: 4,
+  },
+  sectionHeader: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#6B7280',
+    marginTop: 20,
+    marginBottom: 4,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#374151',
+    marginBottom: 6,
+    marginTop: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: '#111827',
+  },
+  textArea: {
+    height: 100,
+    textAlignVertical: 'top',
+  },
+  bodyTypeRow: {
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  bodyTypeBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  bodyTypeBtnActive: {
+    backgroundColor: '#4F46E5',
+    borderColor: '#4F46E5',
+  },
+  bodyTypeBtnText: {
+    fontSize: 14,
+    color: '#374151',
+  },
+  bodyTypeBtnTextActive: {
+    color: '#FFFFFF',
+  },
+});

--- a/components/grm/PipelineView.tsx
+++ b/components/grm/PipelineView.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, FlatList } from 'react-native';
+import { Girl, GRMStatus, GRM_STATUS_LABELS, GRM_STATUS_ORDER } from '@/src/types/grm';
+import { GirlCard } from './GirlCard';
+
+interface Props {
+  girls: Girl[];
+  onSelectGirl: (girl: Girl) => void;
+}
+
+export function PipelineView({ girls, onSelectGirl }: Props) {
+  const byStatus = GRM_STATUS_ORDER.reduce<Record<GRMStatus, Girl[]>>((acc, status) => {
+    acc[status] = girls.filter(g => g.status === status);
+    return acc;
+  }, {} as Record<GRMStatus, Girl[]>);
+
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.container}>
+      <View style={styles.row}>
+        {GRM_STATUS_ORDER.map(status => (
+          <View key={status} style={styles.column}>
+            <View style={styles.columnHeader}>
+              <Text style={styles.columnTitle}>{GRM_STATUS_LABELS[status]}</Text>
+              <View style={styles.countBadge}>
+                <Text style={styles.countText}>{byStatus[status].length}</Text>
+              </View>
+            </View>
+
+            <ScrollView
+              style={styles.columnScroll}
+              showsVerticalScrollIndicator={false}
+              nestedScrollEnabled
+            >
+              {byStatus[status].length === 0 ? (
+                <View style={styles.emptyColumn}>
+                  <Text style={styles.emptyText}>なし</Text>
+                </View>
+              ) : (
+                byStatus[status].map(girl => (
+                  <GirlCard key={girl.id} girl={girl} onPress={onSelectGirl} />
+                ))
+              )}
+            </ScrollView>
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  row: {
+    flexDirection: 'row',
+    padding: 12,
+    gap: 10,
+  },
+  column: {
+    width: 160,
+    backgroundColor: '#F9FAFB',
+    borderRadius: 12,
+    padding: 8,
+    maxHeight: 600,
+  },
+  columnHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+    paddingHorizontal: 2,
+  },
+  columnTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#374151',
+  },
+  countBadge: {
+    backgroundColor: '#E5E7EB',
+    borderRadius: 10,
+    paddingHorizontal: 7,
+    paddingVertical: 1,
+  },
+  countText: {
+    fontSize: 12,
+    color: '#6B7280',
+    fontWeight: '600',
+  },
+  columnScroll: {
+    flex: 1,
+  },
+  emptyColumn: {
+    paddingVertical: 20,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 12,
+    color: '#D1D5DB',
+  },
+});

--- a/components/grm/StatusBadge.tsx
+++ b/components/grm/StatusBadge.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { GRMStatus, GRM_STATUS_LABELS } from '@/src/types/grm';
+
+const STATUS_COLORS: Record<GRMStatus, { bg: string; text: string }> = {
+  lead:       { bg: '#E5E7EB', text: '#374151' },
+  apo_1:      { bg: '#DBEAFE', text: '#1D4ED8' },
+  apo_2:      { bg: '#EDE9FE', text: '#6D28D9' },
+  apo_3:      { bg: '#FCE7F3', text: '#9D174D' },
+  apo_4:      { bg: '#FEF3C7', text: '#92400E' },
+  apo_5plus:  { bg: '#FED7AA', text: '#C2410C' },
+  sex:        { bg: '#DCFCE7', text: '#15803D' },
+  ltr:        { bg: '#FEF9C3', text: '#854D0E' },
+  graduate:   { bg: '#F3F4F6', text: '#6B7280' },
+};
+
+interface Props {
+  status: GRMStatus;
+  size?: 'sm' | 'md';
+}
+
+export function StatusBadge({ status, size = 'md' }: Props) {
+  const colors = STATUS_COLORS[status];
+  const isSmall = size === 'sm';
+
+  return (
+    <View style={[styles.badge, { backgroundColor: colors.bg }, isSmall && styles.badgeSm]}>
+      <Text style={[styles.text, { color: colors.text }, isSmall && styles.textSm]}>
+        {GRM_STATUS_LABELS[status]}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+    alignSelf: 'flex-start',
+  },
+  badgeSm: {
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  text: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  textSm: {
+    fontSize: 11,
+  },
+});

--- a/contexts/GRMContext.tsx
+++ b/contexts/GRMContext.tsx
@@ -1,0 +1,192 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import { Girl, GirlInsert, GirlUpdate, Apo, ApoInsert, GRMStatus } from '@/src/types/grm';
+import * as grmService from '@/src/services/grm';
+import * as apoService from '@/src/services/apo';
+
+interface GRMContextType {
+  girls: Girl[];
+  loading: boolean;
+  error: string | null;
+  fetchGirls: () => Promise<void>;
+  createGirl: (data: Omit<GirlInsert, 'userId'>) => Promise<Girl | null>;
+  updateGirl: (id: string, data: GirlUpdate) => Promise<Girl | null>;
+  updateGirlStatus: (id: string, status: GRMStatus) => Promise<Girl | null>;
+  deleteGirl: (id: string) => Promise<boolean>;
+  getAposByGirl: (girlId: string) => Promise<Apo[]>;
+  addApo: (data: Omit<ApoInsert, 'userId'>) => Promise<Apo | null>;
+  deleteApo: (id: string, girlId: string) => Promise<boolean>;
+}
+
+const GRMContext = createContext<GRMContextType | undefined>(undefined);
+
+export function GRMProvider({ children }: { children: React.ReactNode }) {
+  const [girls, setGirls] = useState<Girl[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchGirls = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data, error } = await grmService.getGirls();
+      if (error) {
+        setError(error.message);
+        return;
+      }
+      setGirls(data || []);
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const createGirl = useCallback(async (data: Omit<GirlInsert, 'userId'>): Promise<Girl | null> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data: girl, error } = await grmService.createGirl(data);
+      if (error) {
+        setError(error.message);
+        return null;
+      }
+      if (girl) {
+        setGirls(prev => [girl, ...prev]);
+      }
+      return girl;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const updateGirl = useCallback(async (id: string, data: GirlUpdate): Promise<Girl | null> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data: updated, error } = await grmService.updateGirl(id, data);
+      if (error) {
+        setError(error.message);
+        return null;
+      }
+      if (updated) {
+        setGirls(prev => prev.map(g => g.id === id ? updated : g));
+      }
+      return updated;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const updateGirlStatus = useCallback(async (id: string, status: GRMStatus): Promise<Girl | null> => {
+    return updateGirl(id, { status });
+  }, [updateGirl]);
+
+  const deleteGirl = useCallback(async (id: string): Promise<boolean> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { error } = await grmService.deleteGirl(id);
+      if (error) {
+        setError(error.message);
+        return false;
+      }
+      setGirls(prev => prev.filter(g => g.id !== id));
+      return true;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const getAposByGirl = useCallback(async (girlId: string): Promise<Apo[]> => {
+    try {
+      const { data, error } = await apoService.getAposByGirl(girlId);
+      if (error) {
+        console.error('アポ取得エラー:', error);
+        return [];
+      }
+      return data || [];
+    } catch (err: any) {
+      console.error('アポ取得エラー:', err);
+      return [];
+    }
+  }, []);
+
+  const addApo = useCallback(async (data: Omit<ApoInsert, 'userId'>): Promise<Apo | null> => {
+    setError(null);
+    try {
+      const { data: apo, error } = await apoService.createApo(data);
+      if (error) {
+        setError(error.message);
+        return null;
+      }
+      // アポ追加後に girls の統計（apo_count/total_spent/status）がDBトリガーで更新されるため再取得
+      if (apo) {
+        const { data: updatedGirl } = await grmService.getGirl(data.girlId);
+        if (updatedGirl) {
+          setGirls(prev => prev.map(g => g.id === data.girlId ? updatedGirl : g));
+        }
+      }
+      return apo;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      return null;
+    }
+  }, []);
+
+  const deleteApo = useCallback(async (id: string, girlId: string): Promise<boolean> => {
+    setError(null);
+    try {
+      const { error } = await apoService.deleteApo(id);
+      if (error) {
+        setError(error.message);
+        return false;
+      }
+      // 削除後に girls の統計を再取得
+      const { data: updatedGirl } = await grmService.getGirl(girlId);
+      if (updatedGirl) {
+        setGirls(prev => prev.map(g => g.id === girlId ? updatedGirl : g));
+      }
+      return true;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      return false;
+    }
+  }, []);
+
+  const value: GRMContextType = {
+    girls,
+    loading,
+    error,
+    fetchGirls,
+    createGirl,
+    updateGirl,
+    updateGirlStatus,
+    deleteGirl,
+    getAposByGirl,
+    addApo,
+    deleteApo,
+  };
+
+  return (
+    <GRMContext.Provider value={value}>
+      {children}
+    </GRMContext.Provider>
+  );
+}
+
+export function useGRM() {
+  const context = useContext(GRMContext);
+  if (context === undefined) {
+    throw new Error('useGRM must be used within a GRMProvider');
+  }
+  return context;
+}

--- a/contexts/SessionContext.tsx
+++ b/contexts/SessionContext.tsx
@@ -1,0 +1,133 @@
+import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import { Session, SessionInsert, SessionUpdate } from '@/src/types/session';
+import * as sessionService from '@/src/services/session';
+
+interface SessionContextType {
+  sessions: Session[];
+  activeSession: Session | null;
+  loading: boolean;
+  error: string | null;
+  fetchSessionsByDate: (date: string) => Promise<void>;
+  startSession: (data: Omit<SessionInsert, 'userId'>) => Promise<Session | null>;
+  updateSession: (id: string, data: SessionUpdate) => Promise<Session | null>;
+  finalizeSession: (id: string) => Promise<Session | null>;
+  setActiveSession: (session: Session | null) => void;
+}
+
+const SessionContext = createContext<SessionContextType | undefined>(undefined);
+
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [activeSession, setActiveSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 今日のセッションを初期ロード
+  useEffect(() => {
+    const today = new Date().toISOString().split('T')[0];
+    fetchSessionsByDate(today);
+  }, []);
+
+  const fetchSessionsByDate = useCallback(async (date: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data, error } = await sessionService.getSessionsByDate(date);
+      if (error) {
+        setError(error.message);
+        return;
+      }
+      const fetched = data || [];
+      setSessions(fetched);
+      // 未確定のセッションをアクティブに設定
+      const unfinalized = fetched.find(s => !s.isFinalized);
+      if (unfinalized) {
+        setActiveSession(unfinalized);
+      }
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const startSession = useCallback(async (data: Omit<SessionInsert, 'userId'>): Promise<Session | null> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data: session, error } = await sessionService.createSession(data);
+      if (error) {
+        setError(error.message);
+        return null;
+      }
+      if (session) {
+        setSessions(prev => [...prev, session]);
+        setActiveSession(session);
+      }
+      return session;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const updateSession = useCallback(async (id: string, data: SessionUpdate): Promise<Session | null> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data: updated, error } = await sessionService.updateSession(id, data);
+      if (error) {
+        setError(error.message);
+        return null;
+      }
+      if (updated) {
+        setSessions(prev => prev.map(s => s.id === id ? updated : s));
+        if (activeSession?.id === id) {
+          setActiveSession(updated);
+        }
+      }
+      return updated;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [activeSession]);
+
+  const finalizeSession = useCallback(async (id: string): Promise<Session | null> => {
+    const result = await updateSession(id, { isFinalized: true });
+    if (result && activeSession?.id === id) {
+      setActiveSession(null);
+    }
+    return result;
+  }, [updateSession, activeSession]);
+
+  const value: SessionContextType = {
+    sessions,
+    activeSession,
+    loading,
+    error,
+    fetchSessionsByDate,
+    startSession,
+    updateSession,
+    finalizeSession,
+    setActiveSession,
+  };
+
+  return (
+    <SessionContext.Provider value={value}>
+      {children}
+    </SessionContext.Provider>
+  );
+}
+
+export function useSession() {
+  const context = useContext(SessionContext);
+  if (context === undefined) {
+    throw new Error('useSession must be used within a SessionProvider');
+  }
+  return context;
+}

--- a/src/services/apo.ts
+++ b/src/services/apo.ts
@@ -1,0 +1,138 @@
+import { supabase } from '@/lib/supabase';
+import { Apo, ApoInsert } from '@/src/types/grm';
+
+// Supabase行データをApo型に変換
+function rowToApo(row: any): Apo {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    girlId: row.girl_id,
+    apoNumber: row.apo_number,
+    apoDate: row.apo_date,
+    location: row.location,
+    spent: row.spent,
+    notes: row.notes,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * アポを追加する（apo_numberはDBトリガーで自動採番）
+ */
+export const createApo = async (
+  data: Omit<ApoInsert, 'userId'>
+): Promise<{ data: Apo | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { data: row, error } = await supabase
+      .from('apos')
+      .insert({
+        user_id: user.id,
+        girl_id: data.girlId,
+        apo_date: data.apoDate,
+        location: data.location ?? null,
+        spent: data.spent ?? 0,
+        notes: data.notes ?? null,
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+    return { data: rowToApo(row), error: null };
+  } catch (error: any) {
+    console.error('アポ追加エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * 特定の女性のアポ履歴を取得する
+ */
+export const getAposByGirl = async (
+  girlId: string
+): Promise<{ data: Apo[] | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { data: rows, error } = await supabase
+      .from('apos')
+      .select('*')
+      .eq('user_id', user.id)
+      .eq('girl_id', girlId)
+      .order('apo_number', { ascending: true });
+
+    if (error) throw error;
+    return { data: (rows || []).map(rowToApo), error: null };
+  } catch (error: any) {
+    console.error('アポ履歴取得エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * アポを更新する
+ */
+export const updateApo = async (
+  id: string,
+  data: { apoDate?: string; location?: string | null; spent?: number; notes?: string | null }
+): Promise<{ data: Apo | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const updateData: any = {};
+    if (data.apoDate !== undefined) updateData.apo_date = data.apoDate;
+    if (data.location !== undefined) updateData.location = data.location;
+    if (data.spent !== undefined) updateData.spent = data.spent;
+    if (data.notes !== undefined) updateData.notes = data.notes;
+
+    const { data: row, error } = await supabase
+      .from('apos')
+      .update(updateData)
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return { data: rowToApo(row), error: null };
+  } catch (error: any) {
+    console.error('アポ更新エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * アポを削除する（DBトリガーが girls.apo_count / total_spent を自動更新）
+ */
+export const deleteApo = async (
+  id: string
+): Promise<{ error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { error } = await supabase
+      .from('apos')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id);
+
+    if (error) throw error;
+    return { error: null };
+  } catch (error: any) {
+    console.error('アポ削除エラー:', error);
+    return { error: error instanceof Error ? error : new Error(error.message) };
+  }
+};

--- a/src/services/grm.ts
+++ b/src/services/grm.ts
@@ -1,0 +1,223 @@
+import { supabase } from '@/lib/supabase';
+import { Girl, GirlInsert, GirlUpdate, GRMStatus } from '@/src/types/grm';
+
+// Supabase行データをGirl型に変換
+function rowToGirl(row: any): Girl {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    sourceSessionId: row.source_session_id,
+    sourceType: row.source_type,
+    nickname: row.nickname,
+    birthday: row.birthday,
+    nationality: row.nationality,
+    occupation: row.occupation,
+    residence: row.residence,
+    height: row.height,
+    bodyType: row.body_type,
+    status: row.status,
+    apoCount: row.apo_count,
+    totalSpent: row.total_spent,
+    rating: row.rating,
+    notes: row.notes,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * 女性を新規登録する
+ */
+export const createGirl = async (
+  data: Omit<GirlInsert, 'userId'>
+): Promise<{ data: Girl | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { data: row, error } = await supabase
+      .from('girls')
+      .insert({
+        user_id: user.id,
+        source_session_id: data.sourceSessionId ?? null,
+        source_type: data.sourceType,
+        nickname: data.nickname,
+        birthday: data.birthday ?? null,
+        nationality: data.nationality ?? null,
+        occupation: data.occupation ?? null,
+        residence: data.residence ?? null,
+        height: data.height ?? null,
+        body_type: data.bodyType ?? null,
+        rating: data.rating ?? null,
+        notes: data.notes ?? null,
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+    return { data: rowToGirl(row), error: null };
+  } catch (error: any) {
+    console.error('女性登録エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * 女性情報を更新する
+ */
+export const updateGirl = async (
+  id: string,
+  data: GirlUpdate
+): Promise<{ data: Girl | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const updateData: any = { updated_at: new Date().toISOString() };
+    if (data.nickname !== undefined) updateData.nickname = data.nickname;
+    if (data.birthday !== undefined) updateData.birthday = data.birthday;
+    if (data.nationality !== undefined) updateData.nationality = data.nationality;
+    if (data.occupation !== undefined) updateData.occupation = data.occupation;
+    if (data.residence !== undefined) updateData.residence = data.residence;
+    if (data.height !== undefined) updateData.height = data.height;
+    if (data.bodyType !== undefined) updateData.body_type = data.bodyType;
+    if (data.status !== undefined) updateData.status = data.status;
+    if (data.rating !== undefined) updateData.rating = data.rating;
+    if (data.notes !== undefined) updateData.notes = data.notes;
+
+    const { data: row, error } = await supabase
+      .from('girls')
+      .update(updateData)
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return { data: rowToGirl(row), error: null };
+  } catch (error: any) {
+    console.error('女性情報更新エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * 全女性一覧を取得する
+ */
+export const getGirls = async (): Promise<{ data: Girl[] | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { data: rows, error } = await supabase
+      .from('girls')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('updated_at', { ascending: false });
+
+    if (error) throw error;
+    return { data: (rows || []).map(rowToGirl), error: null };
+  } catch (error: any) {
+    console.error('女性一覧取得エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * ステータスで絞り込んで女性一覧を取得する
+ */
+export const getGirlsByStatus = async (
+  status: GRMStatus
+): Promise<{ data: Girl[] | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { data: rows, error } = await supabase
+      .from('girls')
+      .select('*')
+      .eq('user_id', user.id)
+      .eq('status', status)
+      .order('updated_at', { ascending: false });
+
+    if (error) throw error;
+    return { data: (rows || []).map(rowToGirl), error: null };
+  } catch (error: any) {
+    console.error('女性ステータス絞り込み取得エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * 特定の女性の詳細を取得する
+ */
+export const getGirl = async (
+  id: string
+): Promise<{ data: Girl | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { data: row, error } = await supabase
+      .from('girls')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') return { data: null, error: null };
+      throw error;
+    }
+    return { data: rowToGirl(row), error: null };
+  } catch (error: any) {
+    console.error('女性詳細取得エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * ステータスを手動変更する（sex / ltr / graduate）
+ */
+export const updateGirlStatus = async (
+  id: string,
+  status: GRMStatus
+): Promise<{ data: Girl | null; error: Error | null }> => {
+  return updateGirl(id, { status });
+};
+
+/**
+ * 女性を削除する
+ */
+export const deleteGirl = async (
+  id: string
+): Promise<{ error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { error } = await supabase
+      .from('girls')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id);
+
+    if (error) throw error;
+    return { error: null };
+  } catch (error: any) {
+    console.error('女性削除エラー:', error);
+    return { error: error instanceof Error ? error : new Error(error.message) };
+  }
+};

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -1,0 +1,189 @@
+import { supabase } from '@/lib/supabase';
+import { Session, SessionInsert, SessionUpdate } from '@/src/types/session';
+
+// Supabase行データをSession型に変換
+function rowToSession(row: any): Session {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    sessionDate: row.session_date,
+    startTime: row.start_time,
+    location: row.location,
+    approached: row.approached,
+    getContact: row.get_contact,
+    instantDate: row.instant_date,
+    instantCv: row.instant_cv,
+    notes: row.notes,
+    isFinalized: row.is_finalized,
+    migratedFromRecordId: row.migrated_from_record_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * 新しいセッションを作成する
+ */
+export const createSession = async (
+  data: Omit<SessionInsert, 'userId'>
+): Promise<{ data: Session | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { data: row, error } = await supabase
+      .from('sessions')
+      .insert({
+        user_id: user.id,
+        session_date: data.sessionDate,
+        start_time: data.startTime ?? null,
+        location: data.location ?? null,
+        approached: data.approached ?? 0,
+        get_contact: data.getContact ?? 0,
+        instant_date: data.instantDate ?? 0,
+        instant_cv: data.instantCv ?? 0,
+        notes: data.notes ?? null,
+        is_finalized: false,
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+    return { data: rowToSession(row), error: null };
+  } catch (error: any) {
+    console.error('セッション作成エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * セッションを更新する
+ */
+export const updateSession = async (
+  id: string,
+  data: SessionUpdate
+): Promise<{ data: Session | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const updateData: any = { updated_at: new Date().toISOString() };
+    if (data.startTime !== undefined) updateData.start_time = data.startTime;
+    if (data.location !== undefined) updateData.location = data.location;
+    if (data.approached !== undefined) updateData.approached = data.approached;
+    if (data.getContact !== undefined) updateData.get_contact = data.getContact;
+    if (data.instantDate !== undefined) updateData.instant_date = data.instantDate;
+    if (data.instantCv !== undefined) updateData.instant_cv = data.instantCv;
+    if (data.notes !== undefined) updateData.notes = data.notes;
+    if (data.isFinalized !== undefined) updateData.is_finalized = data.isFinalized;
+
+    const { data: row, error } = await supabase
+      .from('sessions')
+      .update(updateData)
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return { data: rowToSession(row), error: null };
+  } catch (error: any) {
+    console.error('セッション更新エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * 特定日のセッション一覧を取得する
+ */
+export const getSessionsByDate = async (
+  date: string
+): Promise<{ data: Session[] | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { data: rows, error } = await supabase
+      .from('sessions')
+      .select('*')
+      .eq('user_id', user.id)
+      .eq('session_date', date)
+      .order('created_at', { ascending: true });
+
+    if (error) throw error;
+    return { data: (rows || []).map(rowToSession), error: null };
+  } catch (error: any) {
+    console.error('セッション取得エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * 期間指定でセッション一覧を取得する
+ */
+export const getSessionsByRange = async (
+  startDate: string,
+  endDate: string
+): Promise<{ data: Session[] | null; error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { data: null, error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { data: rows, error } = await supabase
+      .from('sessions')
+      .select('*')
+      .eq('user_id', user.id)
+      .gte('session_date', startDate)
+      .lte('session_date', endDate)
+      .order('session_date', { ascending: true });
+
+    if (error) throw error;
+    return { data: (rows || []).map(rowToSession), error: null };
+  } catch (error: any) {
+    console.error('セッション期間取得エラー:', error);
+    return { data: null, error: error instanceof Error ? error : new Error(error.message) };
+  }
+};
+
+/**
+ * セッションを確定する
+ */
+export const finalizeSession = async (
+  id: string
+): Promise<{ data: Session | null; error: Error | null }> => {
+  return updateSession(id, { isFinalized: true });
+};
+
+/**
+ * セッションを削除する
+ */
+export const deleteSession = async (
+  id: string
+): Promise<{ error: Error | null }> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { error: new Error('ユーザーが認証されていません') };
+    }
+
+    const { error } = await supabase
+      .from('sessions')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id);
+
+    if (error) throw error;
+    return { error: null };
+  } catch (error: any) {
+    console.error('セッション削除エラー:', error);
+    return { error: error instanceof Error ? error : new Error(error.message) };
+  }
+};

--- a/src/types/grm.ts
+++ b/src/types/grm.ts
@@ -1,0 +1,104 @@
+export type GRMStatus =
+  | 'lead'
+  | 'apo_1' | 'apo_2' | 'apo_3' | 'apo_4' | 'apo_5plus'
+  | 'sex' | 'ltr' | 'graduate'
+
+export type BodyType = 'slim' | 'normal' | 'curvy' | 'chubby'
+
+export interface Girl {
+  id: string
+  userId: string
+  sourceSessionId: string | null
+  sourceType: 'get_contact' | 'instant_cv'
+  nickname: string
+  birthday: string | null
+  nationality: string | null
+  occupation: string | null
+  residence: string | null
+  height: number | null
+  bodyType: BodyType | null
+  status: GRMStatus
+  apoCount: number
+  totalSpent: number
+  rating: number | null
+  notes: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface GirlInsert {
+  userId: string
+  sourceSessionId?: string | null
+  sourceType: 'get_contact' | 'instant_cv'
+  nickname: string
+  birthday?: string | null
+  nationality?: string | null
+  occupation?: string | null
+  residence?: string | null
+  height?: number | null
+  bodyType?: BodyType | null
+  rating?: number | null
+  notes?: string | null
+}
+
+export interface GirlUpdate {
+  nickname?: string
+  birthday?: string | null
+  nationality?: string | null
+  occupation?: string | null
+  residence?: string | null
+  height?: number | null
+  bodyType?: BodyType | null
+  status?: GRMStatus
+  rating?: number | null
+  notes?: string | null
+}
+
+export interface Apo {
+  id: string
+  userId: string
+  girlId: string
+  apoNumber: number
+  apoDate: string
+  location: string | null
+  spent: number
+  notes: string | null
+  createdAt: string
+}
+
+export interface ApoInsert {
+  userId: string
+  girlId: string
+  apoDate: string
+  location?: string | null
+  spent?: number
+  notes?: string | null
+}
+
+export interface GRMStats {
+  pipelineCounts: Record<GRMStatus, number>
+  leadToSexRate: number
+  leadToApo1Rate: number
+  avgApoCountToSex: number
+  avgSpentToSex: number
+  avgDaysLeadToApo1: number
+  totalGirls: number
+  totalSpent: number
+  activeGirls: number
+}
+
+export const GRM_STATUS_LABELS: Record<GRMStatus, string> = {
+  lead: 'Lead',
+  apo_1: 'Apo 1',
+  apo_2: 'Apo 2',
+  apo_3: 'Apo 3',
+  apo_4: 'Apo 4',
+  apo_5plus: 'Apo 5+',
+  sex: 'Sex',
+  ltr: 'LTR',
+  graduate: '卒業',
+}
+
+export const GRM_STATUS_ORDER: GRMStatus[] = [
+  'lead', 'apo_1', 'apo_2', 'apo_3', 'apo_4', 'apo_5plus', 'sex', 'ltr', 'graduate'
+]

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,0 +1,39 @@
+export interface Session {
+  id: string
+  userId: string
+  sessionDate: string
+  startTime: string | null
+  location: string | null
+  approached: number
+  getContact: number
+  instantDate: number
+  instantCv: number
+  notes: string | null
+  isFinalized: boolean
+  migratedFromRecordId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SessionInsert {
+  userId: string
+  sessionDate: string
+  startTime?: string | null
+  location?: string | null
+  approached?: number
+  getContact?: number
+  instantDate?: number
+  instantCv?: number
+  notes?: string | null
+}
+
+export interface SessionUpdate {
+  startTime?: string | null
+  location?: string | null
+  approached?: number
+  getContact?: number
+  instantDate?: number
+  instantCv?: number
+  notes?: string | null
+  isFinalized?: boolean
+}

--- a/supabase/migrations/20260328_001_create_sessions.sql
+++ b/supabase/migrations/20260328_001_create_sessions.sql
@@ -1,0 +1,21 @@
+-- sessions テーブル作成（daily_records の後継）
+CREATE TABLE IF NOT EXISTS sessions (
+  id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  session_date               DATE NOT NULL,
+  start_time                 TIME,
+  location                   TEXT,
+  approached                 INTEGER NOT NULL DEFAULT 0,
+  get_contact                INTEGER NOT NULL DEFAULT 0,
+  instant_date               INTEGER NOT NULL DEFAULT 0,
+  instant_cv                 INTEGER NOT NULL DEFAULT 0,
+  notes                      TEXT,
+  is_finalized               BOOLEAN NOT NULL DEFAULT FALSE,
+  migrated_from_record_id    UUID REFERENCES daily_records(id),
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_session_date ON sessions(session_date);
+CREATE INDEX IF NOT EXISTS idx_sessions_user_date ON sessions(user_id, session_date);

--- a/supabase/migrations/20260328_002_create_girls.sql
+++ b/supabase/migrations/20260328_002_create_girls.sql
@@ -1,0 +1,41 @@
+-- girls テーブル作成（GRM本体）
+CREATE TABLE IF NOT EXISTS girls (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  source_session_id UUID REFERENCES sessions(id),
+  source_type       TEXT NOT NULL CHECK (source_type IN ('get_contact', 'instant_cv')),
+
+  -- 基本情報
+  nickname          TEXT NOT NULL,
+  birthday          DATE,
+  nationality       TEXT,
+  occupation        TEXT,
+  residence         TEXT,
+
+  -- 外見
+  height            INTEGER,
+  body_type         TEXT CHECK (body_type IN ('slim', 'normal', 'curvy', 'chubby')),
+
+  -- ステータス管理
+  status            TEXT NOT NULL DEFAULT 'lead'
+                    CHECK (status IN (
+                      'lead',
+                      'apo_1', 'apo_2', 'apo_3', 'apo_4', 'apo_5plus',
+                      'sex', 'ltr', 'graduate'
+                    )),
+
+  -- 自動集計（DBトリガーで更新）
+  apo_count         INTEGER NOT NULL DEFAULT 0,
+  total_spent       INTEGER NOT NULL DEFAULT 0,
+
+  -- 評価
+  rating            INTEGER CHECK (rating BETWEEN 1 AND 10),
+
+  notes             TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_girls_user_id ON girls(user_id);
+CREATE INDEX IF NOT EXISTS idx_girls_status ON girls(status);
+CREATE INDEX IF NOT EXISTS idx_girls_user_status ON girls(user_id, status);

--- a/supabase/migrations/20260328_003_create_apos.sql
+++ b/supabase/migrations/20260328_003_create_apos.sql
@@ -1,0 +1,16 @@
+-- apos テーブル作成（アポ履歴）
+CREATE TABLE IF NOT EXISTS apos (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  girl_id      UUID NOT NULL REFERENCES girls(id) ON DELETE CASCADE,
+  apo_number   INTEGER NOT NULL,
+  apo_date     DATE NOT NULL,
+  location     TEXT,
+  spent        INTEGER NOT NULL DEFAULT 0,
+  notes        TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_apos_user_id ON apos(user_id);
+CREATE INDEX IF NOT EXISTS idx_apos_girl_id ON apos(girl_id);
+CREATE INDEX IF NOT EXISTS idx_apos_apo_date ON apos(apo_date);

--- a/supabase/migrations/20260328_004_triggers.sql
+++ b/supabase/migrations/20260328_004_triggers.sql
@@ -1,0 +1,55 @@
+-- apos 変更時に girls の統計を自動更新するトリガー
+CREATE OR REPLACE FUNCTION sync_girl_stats()
+RETURNS TRIGGER AS $$
+DECLARE
+  target_girl_id UUID;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    target_girl_id := OLD.girl_id;
+  ELSE
+    target_girl_id := NEW.girl_id;
+  END IF;
+
+  UPDATE girls SET
+    apo_count   = (SELECT COUNT(*)                    FROM apos WHERE girl_id = target_girl_id),
+    total_spent = (SELECT COALESCE(SUM(spent), 0)     FROM apos WHERE girl_id = target_girl_id),
+    status      = (
+      CASE
+        WHEN status IN ('sex', 'ltr', 'graduate') THEN status
+        WHEN (SELECT COUNT(*) FROM apos WHERE girl_id = target_girl_id) = 0 THEN 'lead'
+        WHEN (SELECT COUNT(*) FROM apos WHERE girl_id = target_girl_id) = 1 THEN 'apo_1'
+        WHEN (SELECT COUNT(*) FROM apos WHERE girl_id = target_girl_id) = 2 THEN 'apo_2'
+        WHEN (SELECT COUNT(*) FROM apos WHERE girl_id = target_girl_id) = 3 THEN 'apo_3'
+        WHEN (SELECT COUNT(*) FROM apos WHERE girl_id = target_girl_id) = 4 THEN 'apo_4'
+        ELSE 'apo_5plus'
+      END
+    ),
+    updated_at  = NOW()
+  WHERE id = target_girl_id;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_apos_sync_girl_stats ON apos;
+CREATE TRIGGER trg_apos_sync_girl_stats
+AFTER INSERT OR UPDATE OR DELETE ON apos
+FOR EACH ROW EXECUTE FUNCTION sync_girl_stats();
+
+-- apo_number 自動採番トリガー
+CREATE OR REPLACE FUNCTION set_apo_number()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.apo_number := (
+    SELECT COALESCE(MAX(apo_number), 0) + 1
+    FROM apos
+    WHERE girl_id = NEW.girl_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_apos_set_number ON apos;
+CREATE TRIGGER trg_apos_set_number
+BEFORE INSERT ON apos
+FOR EACH ROW EXECUTE FUNCTION set_apo_number();

--- a/supabase/migrations/20260328_005_rls_policies.sql
+++ b/supabase/migrations/20260328_005_rls_policies.sql
@@ -1,0 +1,22 @@
+-- RLS ポリシー設定（全テーブル共通）
+ALTER TABLE sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE girls    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE apos     ENABLE ROW LEVEL SECURITY;
+
+-- sessions ポリシー
+DROP POLICY IF EXISTS "users own sessions" ON sessions;
+CREATE POLICY "users own sessions" ON sessions
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- girls ポリシー
+DROP POLICY IF EXISTS "users own girls" ON girls;
+CREATE POLICY "users own girls" ON girls
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- apos ポリシー
+DROP POLICY IF EXISTS "users own apos" ON apos;
+CREATE POLICY "users own apos" ON apos
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());

--- a/supabase/migrations/20260328_006_migrate_daily_records.sql
+++ b/supabase/migrations/20260328_006_migrate_daily_records.sql
@@ -1,0 +1,23 @@
+-- daily_records → sessions データ移行
+-- 既存レコードを sessions に1:1でコピー
+INSERT INTO sessions (
+  user_id, session_date, approached, get_contact,
+  instant_date, instant_cv, is_finalized, migrated_from_record_id,
+  created_at, updated_at
+)
+SELECT
+  user_id,
+  game_date,
+  approached,
+  get_contact,
+  instant_date,
+  instant_cv,
+  TRUE,
+  id,
+  created_at,
+  updated_at
+FROM daily_records
+ON CONFLICT DO NOTHING;
+
+-- daily_records テーブルはロールバック保険として残す（後で削除）
+-- DROP TABLE daily_records;


### PR DESCRIPTION
Phase 1-3 (DB/型/サービス/Context/UI) を実装:

- supabase/migrations: sessions/girls/apos テーブル + トリガー + RLS + データ移行
- src/types: Session・Girl・Apo の TypeScript 型定義
- src/services: session / grm / apo の Supabase CRUD サービス層
- contexts: SessionContext・GRMContext
- components/grm: StatusBadge / GirlCard / GirlListView / PipelineView /
  GirlDetailView / ApoTimeline / AddApoForm / GirlRegistrationForm
- app/(tabs)/grm.tsx: GRM メイン画面（パイプライン/リスト切り替え）
- app/(tabs)/_layout.tsx: GRM タブ追加
- app/_layout.tsx: SessionProvider・GRMProvider を注入

https://claude.ai/code/session_0161ZQgeGF7H9U5NcEsNwXYw